### PR TITLE
ci: route linux x64 jobs to self-hosted podman fleet

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
Adapts GitHub Actions for the shared **gha-runner-ctl** WSL fleet.

## Changes
- `runs-on: [self-hosted, linux, x64, podman]` for linux x64 jobs
- Matrix/release linux legs mapped to fleet labels; macOS/Windows/ARM64 unchanged
- Push/PR triggers added on primary CI workflows that were manual-only

## Fleet labels
CPU: `[self-hosted, linux, x64, podman]` · GPU (occasional): add `gpu` label